### PR TITLE
* [jsfm] 在 scroll.js 中取消使用 arguments.callee

### DIFF
--- a/html5/browser/scroll.js
+++ b/html5/browser/scroll.js
@@ -1026,12 +1026,14 @@ function Scroll(element, options) {
           setTransitionStyle(that, '0.4s', 'ease-in-out')
           setTransformStyle(that, offset)
 
-          lib.animation.requestFrame(function () {
+          function _cancelScroll() {
             if (isScrolling && that.enabled) {
               fireEvent(that, 'scrolling')
-              lib.animation.requestFrame(arguments.callee)
+              lib.animation.requestFrame(_cancelScroll)
             }
-          })
+          }
+
+          lib.animation.requestFrame(_cancelScroll)
         }
       } else {
         if (!this.options.useFrameAnimation) {
@@ -1198,4 +1200,3 @@ lib.scroll.plugin = function (name, constructor) {
     return plugins[name]
   }
 }
-


### PR DESCRIPTION
将回调函数抽离出来并且命名，避免在严格模式中出现错误
